### PR TITLE
msm8226-common: Move audio calibration files to devices

### DIFF
--- a/proprietary-files.txt
+++ b/proprietary-files.txt
@@ -10,13 +10,6 @@ vendor/lib/rfsa/adsp/libfastcvadsp.so
 vendor/lib/rfsa/adsp/libfastcvadsp_skel.so
 
 # Audio
-etc/Bluetooth_cal.acdb
-etc/General_cal.acdb
-etc/Global_cal.acdb
-etc/Handset_cal.acdb
-etc/Hdmi_cal.acdb
-etc/Headset_cal.acdb
-etc/Speaker_cal.acdb
 vendor/lib/libacdbloader.so
 vendor/lib/libacdbrtac.so
 vendor/lib/libadiertac.so


### PR DESCRIPTION
Titan can't use them so move them to devices instead.

Change-Id: Id318227ec9aacf9339c104d4d2dc9d9306396dff